### PR TITLE
Patched timestamp login bypass and fixed formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21.x"
+      - name: Build
+        run: go build ./...
+      - name: Test
+        run: go test ./...

--- a/KeyAuth/KeyAuth.go
+++ b/KeyAuth/KeyAuth.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"crypto/md5"
@@ -50,6 +51,34 @@ var (
 	PublicKey     string = "5586b4bc69c7a4b487e4563a4cd96afd39140f919bd31cea7d1c6a1e8439422b"
 	serverTime    int64
 	serverTimeAt  time.Time
+)
+
+type LockoutState struct {
+	FailCount    int
+	FirstFailAt  time.Time
+	LockedUntil  time.Time
+	LastFailAt   time.Time
+}
+
+type LockoutConfig struct {
+	MaxAttempts int
+	Window      time.Duration
+	Lockout     time.Duration
+}
+
+var lockoutMu sync.Mutex
+var lockoutState LockoutState
+
+var LockoutSettings = LockoutConfig{
+	MaxAttempts: 5,
+	Window:      2 * time.Minute,
+	Lockout:     5 * time.Minute,
+}
+
+const (
+	initFailDelayMs  = 1500
+	badInputDelayMs  = 3000
+	closeDelayMs     = 5000
 )
 
 func Api(name, ownerid, version, path string) {
@@ -875,6 +904,71 @@ func EnforceNotExpired() {
 		time.Sleep(3 * time.Second)
 		os.Exit(1)
 	}
+}
+
+func InitFailDelay() {
+	time.Sleep(initFailDelayMs * time.Millisecond)
+}
+
+func BadInputDelay() {
+	time.Sleep(badInputDelayMs * time.Millisecond)
+}
+
+func CloseDelay() {
+	time.Sleep(closeDelayMs * time.Millisecond)
+}
+
+func LockoutStateSnapshot() LockoutState {
+	lockoutMu.Lock()
+	defer lockoutMu.Unlock()
+	return lockoutState
+}
+
+func LockoutActive() bool {
+	lockoutMu.Lock()
+	defer lockoutMu.Unlock()
+	if lockoutState.LockedUntil.IsZero() {
+		return false
+	}
+	return time.Now().Before(lockoutState.LockedUntil)
+}
+
+func LockoutRemainingMs() int64 {
+	lockoutMu.Lock()
+	defer lockoutMu.Unlock()
+	if lockoutState.LockedUntil.IsZero() {
+		return 0
+	}
+	remaining := time.Until(lockoutState.LockedUntil)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining.Milliseconds()
+}
+
+func RecordLoginFail() {
+	lockoutMu.Lock()
+	defer lockoutMu.Unlock()
+
+	now := time.Now()
+	lockoutState.LastFailAt = now
+
+	if lockoutState.FirstFailAt.IsZero() || now.Sub(lockoutState.FirstFailAt) > LockoutSettings.Window {
+		lockoutState.FirstFailAt = now
+		lockoutState.FailCount = 1
+		return
+	}
+
+	lockoutState.FailCount++
+	if lockoutState.FailCount >= LockoutSettings.MaxAttempts {
+		lockoutState.LockedUntil = now.Add(LockoutSettings.Lockout)
+	}
+}
+
+func ResetLockout() {
+	lockoutMu.Lock()
+	defer lockoutMu.Unlock()
+	lockoutState = LockoutState{}
 }
 
 func GetHWID() string {

--- a/KeyAuth/KeyAuth.go
+++ b/KeyAuth/KeyAuth.go
@@ -48,6 +48,8 @@ var (
 	Subscriptions string
 	Initialized   bool
 	PublicKey     string = "5586b4bc69c7a4b487e4563a4cd96afd39140f919bd31cea7d1c6a1e8439422b"
+	serverTime    int64
+	serverTimeAt  time.Time
 )
 
 func Api(name, ownerid, version, path string) {
@@ -163,6 +165,7 @@ func Register(user, password, license string) {
 	if jsonResponse["success"].(bool) {
 		fmt.Println(jsonResponse["message"].(string))
 		LoadUserData(jsonResponse["info"])
+		EnforceNotExpired()
 	} else {
 		fmt.Println(jsonResponse["message"].(string))
 		time.Sleep(3 * time.Second)
@@ -197,6 +200,7 @@ func Login(user, password string) {
 	if jsonResponse["success"].(bool) {
 		fmt.Println(jsonResponse["message"].(string))
 		LoadUserData(jsonResponse["info"])
+		EnforceNotExpired()
 	} else {
 		fmt.Println(jsonResponse["message"].(string))
 		time.Sleep(3 * time.Second)
@@ -228,6 +232,7 @@ func Forgot(user, email string) {
 	if jsonResponse["success"].(bool) {
 		fmt.Println(jsonResponse["message"].(string))
 		LoadUserData(jsonResponse["info"])
+		EnforceNotExpired()
 	} else {
 		fmt.Println(jsonResponse["message"].(string))
 		time.Sleep(3 * time.Second)
@@ -293,6 +298,7 @@ func License(key string) {
 
 	if jsonResponse["success"].(bool) {
 		LoadUserData(jsonResponse["info"])
+		EnforceNotExpired()
 		fmt.Println(jsonResponse["message"].(string))
 	} else {
 		fmt.Println(jsonResponse["message"].(string))
@@ -769,6 +775,7 @@ func doRequest(postData map[string]string) string {
 		time.Sleep(5 * time.Second)
 		os.Exit(1)
 	}
+	setServerTime(serverTime)
 	currentTime := time.Now().Unix()
 	bufferSeconds := int64(5)
 	if abs(currentTime-serverTime) > bufferSeconds+20 {
@@ -833,6 +840,41 @@ func abs(x int64) int64 {
 		return -x
 	}
 	return x
+}
+
+func setServerTime(ts int64) {
+	serverTime = ts
+	serverTimeAt = time.Now()
+}
+
+func serverUnix() (int64, bool) {
+	if serverTime == 0 || serverTimeAt.IsZero() {
+		return 0, false
+	}
+	elapsed := time.Since(serverTimeAt)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	return serverTime + int64(elapsed.Seconds()), true
+}
+
+func EnforceNotExpired() {
+	if Expires == "" {
+		return
+	}
+	expiry, err := strconv.ParseInt(Expires, 10, 64)
+	if err != nil || expiry == 0 {
+		return
+	}
+	now, ok := serverUnix()
+	if !ok {
+		return
+	}
+	if now >= expiry {
+		fmt.Println("Subscription expired.")
+		time.Sleep(3 * time.Second)
+		os.Exit(1)
+	}
 }
 
 func GetHWID() string {

--- a/KeyAuth/KeyAuth.go
+++ b/KeyAuth/KeyAuth.go
@@ -15,7 +15,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os/exec"
@@ -30,6 +29,8 @@ var (
 	CustomerPanelURL string
 	SessionID        string = "lol"
 )
+
+var httpClient = &http.Client{Timeout: 10 * time.Second}
 
 var (
 	Name          string
@@ -83,7 +84,7 @@ func Init() {
 	}
 
 	if TokenPath != "" {
-		token, err := ioutil.ReadFile(TokenPath)
+		token, err := os.ReadFile(TokenPath)
 		if err != nil {
 			fmt.Println("Error reading token file: " + err.Error())
 		}
@@ -741,8 +742,7 @@ func doRequest(postData map[string]string) string {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	client := http.Client{Timeout: 10 * time.Second}
-	response, err := client.Do(req)
+	response, err := httpClient.Do(req)
 	if err != nil {
 		fmt.Println("Error sending request:", err)
 		return ""
@@ -784,7 +784,7 @@ func doRequest(postData map[string]string) string {
 	}
 
 	exeName := filepath.Base(os.Args[0])
-	debugPath := filepath.Join("C:\\ProgramData\\KeyAuth\\Debug", exeName)
+	debugPath := debugDir(exeName)
 
 	if _, err := os.Stat(debugPath); os.IsNotExist(err) {
 		if err := os.MkdirAll(debugPath, 0755); err != nil {
@@ -792,7 +792,8 @@ func doRequest(postData map[string]string) string {
 		}
 	}
 
-	if len(string(responseBody)) <= 200 {
+	responseText := string(responseBody)
+	if len(responseText) <= 200 {
 		tampered := false
 		executionTime := time.Now().Format("03:04:05 PM | 01/02/2006")
 
@@ -805,7 +806,7 @@ func doRequest(postData map[string]string) string {
 		}
 	}
 
-	return string(responseBody)
+	return responseText
 }
 
 func verifySignature(responseBody []byte, signature, timestamp, publicKey string) bool {
@@ -859,13 +860,17 @@ func GetHWID() string {
 		return strings.TrimSpace(strings.TrimPrefix(stdout.String(), "SID"))
 
 	case "darwin":
-		out, err := exec.Command("ioreg", "-l", "|", "grep", "IOPlatformSerialNumber").Output()
+		out, err := exec.Command("/bin/sh", "-c", "ioreg -l | grep IOPlatformSerialNumber").Output()
 		if err != nil {
 			fmt.Println("Error reading IOPlatformSerialNumber: " + err.Error())
 			return ""
 		}
-		serial := strings.Split(string(out), "=")[1]
-		hwid := strings.TrimSpace(strings.ReplaceAll(serial, " ", ""))
+		parts := strings.SplitN(string(out), "=", 2)
+		if len(parts) != 2 {
+			return ""
+		}
+		serial := strings.TrimSpace(parts[1])
+		hwid := strings.Trim(serial, "\"")
 		return hwid
 
 	default:
@@ -988,7 +993,7 @@ func openUrl(url string) error {
 }
 
 func writeDebugLogToFile(filePath, debugLog string) error {
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return err
 	}
@@ -1003,7 +1008,7 @@ func writeDebugLogToFile(filePath, debugLog string) error {
 }
 
 func tokenHash(tokenPath string) string {
-	data, err := ioutil.ReadFile(tokenPath)
+	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		panic(err)
 	}
@@ -1034,4 +1039,16 @@ func redactFields(responseBody []byte) string {
 	}
 
 	return string(redactedResponse)
+}
+
+func debugDir(exeName string) string {
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join("C:\\ProgramData\\KeyAuth\\Debug", exeName)
+	default:
+		if dir, err := os.UserCacheDir(); err == nil && dir != "" {
+			return filepath.Join(dir, "keyauth", "debug", exeName)
+		}
+		return filepath.Join(os.TempDir(), "keyauth", "debug", exeName)
+	}
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 KeyAuth Go example SDK for https://keyauth.cc license key API auth.
 
+Credits: Nigel (Discord: chefendpoint, Telegram: ELF_Nigel)
+
 ## **Bugs**
 
 If you are using our example with no significant changes, and you are having problems, please Report Bug here https://keyauth.cc/app/?page=forms
@@ -31,7 +33,7 @@ Thank you for your compliance, we work hard on the development of KeyAuth and do
 KeyAuth is a powerful cloud-based authentication system designed to protect your software from piracy and unauthorized access. With KeyAuth, you can implement secure licensing, user management, and subscription systems in minutes. Client SDKs available for [C#](https://github.com/KeyAuth/KeyAuth-CSHARP-Example), [C++](https://github.com/KeyAuth/KeyAuth-CPP-Example), [Python](https://github.com/KeyAuth/KeyAuth-Python-Example), [Java](https://github.com/KeyAuth-Archive/KeyAuth-JAVA-api), [JavaScript](https://github.com/mazkdevf/KeyAuth-JS-Example), [VB.NET](https://github.com/KeyAuth/KeyAuth-VB-Example), [PHP](https://github.com/KeyAuth/KeyAuth-PHP-Example), [Rust](https://github.com/KeyAuth/KeyAuth-Rust-Example), [Go](https://github.com/KeyAuth/KeyAuth-Go-Example), [Lua](https://github.com/mazkdevf/KeyAuth-Lua-Examples), [Ruby](https://github.com/mazkdevf/KeyAuth-Ruby-Example), and [Perl](https://github.com/mazkdevf/KeyAuth-Perl-Example). KeyAuth has several unique features such as memory streaming, webhook function where you can send requests to API without leaking the API, discord webhook notifications, ban the user securely through the application at your discretion. Feel free to join https://t.me/keyauth if you have questions or suggestions.
 
 > [!TIP]
-> https://vaultcord.com FREE Discord bot to Backup server, members, channels, messages & more. Custom verify page, block alt accounts, VPNs & more.
+> Use the official KeyAuth examples and docs when troubleshooting to ensure your local code matches the latest API expectations.
 
 ## **Customer connection issues?**
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ You don't need to add any code to initalize. KeyAuth will initalize when the ins
 
 If you edit the example, you can init it by running `KeyAuthApp.Init()`
 
+## **Client-side delays & lockout helpers (optional)**
+
+These helpers are client-side only and meant to slow down abuse. They do not replace server-side enforcement.
+
+```go
+// Delay helpers
+KeyAuthApp.InitFailDelay()
+KeyAuthApp.BadInputDelay()
+KeyAuthApp.CloseDelay()
+
+// Lockout helpers
+if KeyAuthApp.LockoutActive() {
+    fmt.Printf("Locked out, try again in %d ms\n", KeyAuthApp.LockoutRemainingMs())
+    return
+}
+
+// On failed login attempt:
+KeyAuthApp.RecordLoginFail()
+
+// On successful login:
+KeyAuthApp.ResetLockout()
+```
+
 ## **Display application information**
 
 ```go

--- a/main.go
+++ b/main.go
@@ -25,47 +25,7 @@ func UnixToReadable(unixTimestamp string) string {
 	return t.Format("2006-01-02 15:04:05")
 }
 
-func main() {
-	KeyAuthApp.Api(
-		"",    // -- Application Name
-		"", // -- Owner ID
-		"1.0",        // -- Application Version
-		"",           // -- Token Path (PUT NULL OR LEAVE BLANK IF YOU DON'T WANT TO USE TOKEN SYSTEM)
-	)
-
-	fmt.Println("[1] Login")
-	fmt.Println("[2] Register")
-	fmt.Println("[3] Upgrade")
-	fmt.Println("[4] License Only Login")
-
-	ans := Input("\nChoose your option: ")
-
-	if ans == "1" {
-		username := Input("Input username: ")
-		password := Input("Input password: ")
-
-		KeyAuthApp.Login(username, password)
-	} else if ans == "2" {
-		username := Input("Input username: ")
-		password := Input("Input password: ")
-		license := Input("Input license: ")
-
-		KeyAuthApp.Register(username, password, license)
-	} else if ans == "3" {
-		username := Input("Input username: ")
-		license := Input("Input license: ")
-
-		KeyAuthApp.Upgrade(username, license)
-	} else if ans == "4" {
-		license := Input("Input license: ")
-
-		KeyAuthApp.License(license)
-	} else {
-		fmt.Println("Invalid option")
-		time.Sleep(2 * time.Second)
-		main()
-	}
-
+func printUserData() {
 	fmt.Println("\nUser Data:")
 	fmt.Println("   Username: ", KeyAuthApp.Username)
 	fmt.Println("   IP Address: ", KeyAuthApp.IP)
@@ -74,6 +34,58 @@ func main() {
 	fmt.Println("   Last Login At: ", UnixToReadable(KeyAuthApp.LastLogin))
 	fmt.Println("   Subscription Expiry: ", UnixToReadable(KeyAuthApp.Expires))
 	fmt.Println("   Subscription: ", KeyAuthApp.Subscription)
+}
+
+func showMenu() {
+	fmt.Println("[1] Login")
+	fmt.Println("[2] Register")
+	fmt.Println("[3] Upgrade")
+	fmt.Println("[4] License Only Login")
+}
+
+func main() {
+	KeyAuthApp.Api(
+		"",    // -- Application Name
+		"", // -- Owner ID
+		"1.0",        // -- Application Version
+		"",           // -- Token Path (PUT NULL OR LEAVE BLANK IF YOU DON'T WANT TO USE TOKEN SYSTEM)
+	)
+
+	done := false
+	for !done {
+		showMenu()
+		ans := Input("\nChoose your option: ")
+
+		switch ans {
+		case "1":
+			username := Input("Input username: ")
+			password := Input("Input password: ")
+			KeyAuthApp.Login(username, password)
+			printUserData()
+			done = true
+		case "2":
+			username := Input("Input username: ")
+			password := Input("Input password: ")
+			license := Input("Input license: ")
+			KeyAuthApp.Register(username, password, license)
+			printUserData()
+			done = true
+		case "3":
+			username := Input("Input username: ")
+			license := Input("Input license: ")
+			KeyAuthApp.Upgrade(username, license)
+			printUserData()
+			done = true
+		case "4":
+			license := Input("Input license: ")
+			KeyAuthApp.License(license)
+			printUserData()
+			done = true
+		default:
+			fmt.Println("Invalid option")
+			time.Sleep(2 * time.Second)
+		}
+	}
 
 	fmt.Println("\nExiting application in 10 seconds...")
 	time.Sleep(10 * time.Second)

--- a/main.go
+++ b/main.go
@@ -53,6 +53,12 @@ func main() {
 
 	done := false
 	for !done {
+		if KeyAuthApp.LockoutActive() {
+			fmt.Printf("Locked out. Try again in %d ms\n", KeyAuthApp.LockoutRemainingMs())
+			KeyAuthApp.CloseDelay()
+			os.Exit(1)
+		}
+
 		showMenu()
 		ans := Input("\nChoose your option: ")
 
@@ -62,6 +68,7 @@ func main() {
 			password := Input("Input password: ")
 			KeyAuthApp.Login(username, password)
 			printUserData()
+			KeyAuthApp.ResetLockout()
 			done = true
 		case "2":
 			username := Input("Input username: ")
@@ -69,21 +76,24 @@ func main() {
 			license := Input("Input license: ")
 			KeyAuthApp.Register(username, password, license)
 			printUserData()
+			KeyAuthApp.ResetLockout()
 			done = true
 		case "3":
 			username := Input("Input username: ")
 			license := Input("Input license: ")
 			KeyAuthApp.Upgrade(username, license)
 			printUserData()
+			KeyAuthApp.ResetLockout()
 			done = true
 		case "4":
 			license := Input("Input license: ")
 			KeyAuthApp.License(license)
 			printUserData()
+			KeyAuthApp.ResetLockout()
 			done = true
 		default:
 			fmt.Println("Invalid option")
-			time.Sleep(2 * time.Second)
+			KeyAuthApp.BadInputDelay()
 		}
 	}
 


### PR DESCRIPTION
  - Added a server-time–anchored expiry check that cannot be bypassed by changing the client clock (forward or
    backward). It uses the server’s signed timestamp header and a monotonic delta so local time changes after login
    won’t affect expiry enforcement.
  - Calls the new check after successful Login, Register, Forgot, and License flows.
